### PR TITLE
fixes related to images

### DIFF
--- a/Export_deck_to_HTML.py
+++ b/Export_deck_to_HTML.py
@@ -164,8 +164,7 @@ class AddonDialog(QDialog):
         note = card.note()
         model = note.model()
         fields = card.note().keys()
-        return fields
-    # Function to convert   
+        return fields 
 
     def _on_accept(self):
         dialog = SaveFileDialog(self.deck_selection.currentText())

--- a/Export_deck_to_HTML.py
+++ b/Export_deck_to_HTML.py
@@ -165,7 +165,7 @@ class AddonDialog(QDialog):
         model = note.model()
         fields = card.note().keys()
         return fields
-
+    # Function to convert   
 
     def _on_accept(self):
         dialog = SaveFileDialog(self.deck_selection.currentText())
@@ -193,17 +193,19 @@ class AddonDialog(QDialog):
                         try:
                             value = card.note()[field[2:-2]]
                         except:
-                            continue
+                            if field == "{{Front}}":
+                                value = card.note()['Text'] #to support cloze deletion cards/Front
+                            else:
+                                value = card.note()['Extra'] #to support cloze deletion cards/Back
+                            value = re.sub(r'{{[c|C][0-9]+::(.*?)}}',r'\g<1>',value) # get rid of the colze deletion formatting e.g. {{c1::someText}}
                         pictures = re.findall(r'src=["|' + "']" + "(.*?)['|" + '"]', value) #to find src='()' or src="()"
                         img_tmp01 = 'src="%s"'
                         img_tmp02 = "src='%s'"
                         if len(pictures):
-                            #value = ""
                             for pic in pictures:
                                 full_img_path = os.path.join(collection_path, pic)
                                 value = value.replace(img_tmp01 % pic, img_tmp01 % full_img_path)
                                 value = value.replace(img_tmp02 % pic, img_tmp02 % full_img_path)
-                                #value += img_tag
                         card_html = card_html.replace("%s" % field, value)
                     html += card_html
 


### PR DESCRIPTION
Hello @TruongQToan , thanks for sharing your add-on.
it was very helpful to me, but i found some errors and edited them with my basic experience with python (only started learning it a couple of months ago ).

changes as the following:
1.Changed img regex lookup from <img src="(.\*?)" to src=\['|"](.\*?)\['|"] as the old one will not capture image elements with class or style, or img links elements with an apostrophe e.g. src='xxx'
2.Fixed only images appearing when a field has both images and text,
3.Added error handler before value = card.note()[field[2:-2]] as it was failing on cards with type of "Cloze" ( don't have enough info on how to handle this type)

My base code for editing was the file that was installed with the add-on, and that is why there are other changes in comparison with the file in this repository.
